### PR TITLE
bugfix: Handling of unknown desired plotting values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dlptools
 Title: DLPTools: Handling DLP+ Data
-Version: 0.3.2
+Version: 0.3.3
 Authors@R: 
     person("Ben", "Furman", , "bfurman@bccrc.ca", role = c("aut", "cre"))
 Description: A collections of functions for basic manipulation and plotting of

--- a/R/heatmap_plot.R
+++ b/R/heatmap_plot.R
@@ -53,7 +53,7 @@ import_annotations_df <- function(annotations_file) {
 #' @export
 #' @importFrom rlang .data
 format_states_for_hm <- function(
-    states_df, state_col, continuous = FALSE, replace_11_with_11plus = TRUE) {
+    states_df, state_col, continuous = FALSE) {
   states_w <- states_df |>
     dplyr::select(cell_id, chr, start, end, state_col) |>
     convert_long_reads_to_wide(state_col = state_col)
@@ -67,13 +67,6 @@ format_states_for_hm <- function(
 
   # sort columns by chromosome and bin start_end
   states_mat <- states_mat[, gtools::mixedsort(base::colnames(states_mat))]
-  if (!(state_col == "BAF" || continuous)) {
-    base::class(states_mat) <- "character"
-  }
-
-  if (state_col == "state" && replace_11_with_11plus) {
-    states_mat[states_mat == "11"] <- "11+"
-  }
 
   return(states_mat)
 }
@@ -113,14 +106,19 @@ create_chromosome_column_fct <- function(states_mat) {
 #' creates a complex heatmap of a given matrix of states.
 generate_state_hm <- function(
     states_mat, labels_fontsize = 8, plot_cols = STATE_COLORS,
-    left_annot = NULL) {
+    left_annot = NULL, legend_11plus = FALSE) {
   # set up a chromosome factor for column splits in the heatmap
   chroms <- create_chromosome_column_fct(states_mat)
 
-  # this is a little special case catch for how we tend to handle 11s. 11+
-  # is introduced when formatting the matrix for states.
-  if ("11+" %in% states_mat && !("11+" %in% names(plot_cols))) {
-    plot_cols["11+"] <- plot_cols["11"]
+  if (legend_11plus) {
+    # fix for HMMcopy states where 11 is really 11+, so we can reflect that
+    # in the legend
+    legend_params <- list(
+      nrow = 4,
+      title = "state", at = 1:11, labels = c(1:10, "11+"), legend_gp = dlptools::CNV_COLOURS
+    )
+  } else {
+    legend_params <- list(nrow = 4)
   }
 
   states_hm <- ComplexHeatmap::Heatmap(
@@ -136,7 +134,7 @@ generate_state_hm <- function(
     column_title_side = "bottom",
     # might need to revisit when I size img
     column_title_gp = grid::gpar(fontsize = labels_fontsize),
-    heatmap_legend_param = list(nrow = 4),
+    heatmap_legend_param = legend_params, # list(nrow = 4),
     na_col = "white",
     left_annotation = left_annot
   )
@@ -482,8 +480,9 @@ check_or_fetch_clone_palette <- function(clones_df, clone_palette = NULL) {
 #' and high bounds for the continuous color scale, e.g., c(1, 5, 10)
 #' @param hm_discrete_colors specified colors for the values being plotted.
 #' Named vector: c(1="#3182BD", 2="#FDCC8A"). Need to specify for every value
-#' @param replace_11_with_11plus bool. Default TRUE. For HMMCopy state values,
-#' state 11 is really 11+, so we replace 11s with 11+ for the plot.
+#' @param legend_11plus bool. Default FALSE. For HMMCopy state values,
+#' state 11 is really 11+, so we replace 11s with 11+ for the plot in the
+#' legend.
 #' being plotted
 #' @export
 plot_state_hm <- function(
@@ -504,7 +503,7 @@ plot_state_hm <- function(
     custom_continuous_colors = NULL,
     custom_continuous_range = NULL,
     hm_discrete_colors = NULL,
-    replace_11_with_11plus = TRUE,
+    legend_11plus = FALSE,
     ...) {
   check_args()
 
@@ -512,8 +511,7 @@ plot_state_hm <- function(
   states_mat <- format_states_for_hm(
     states_df,
     state_col,
-    continuous = continuous_hm_colours,
-    replace_11_with_11plus = replace_11_with_11plus
+    continuous = continuous_hm_colours
   )
 
   # deal with any annotations
@@ -593,7 +591,8 @@ plot_state_hm <- function(
     states_mat,
     plot_cols = hm_colors,
     labels_fontsize = labels_fontsize,
-    left_annot = left_annot
+    left_annot = left_annot,
+    legend_11plus = legend_11plus
   )
 
   if (!is.null(tree_hm)) {

--- a/R/heatmap_plot.R
+++ b/R/heatmap_plot.R
@@ -229,6 +229,16 @@ fetch_heatmap_color_palette <- function(
   plot_col_elements <- plot_col_elements[!is.na(plot_col_elements)]
   too_many_colors <- length(plot_col_elements) > length(color_chosen)
   way_too_many_colors <- length(plot_col_elements) > max_colors
+  all_values_in_palette <- all(plot_col_elements %in% names(color_chosen))
+  if (!all_values_in_palette) {
+    palette_vals <- paste(c(names(color_chosen), "NA"), collapse = ", ")
+    stop(paste0(
+      "There are values in the plotted column: '", state_col, "' that the ",
+      "automatically chosen color palette does not have. You'll need to ",
+      "either convert those to NAs or specify the plot colors you want.",
+      "Palette handles: ", palette_vals
+    ))
+  }
   if (state_col != "BAF" && (too_many_colors || way_too_many_colors)) {
     warning(
       paste0(

--- a/R/heatmap_plot.R
+++ b/R/heatmap_plot.R
@@ -62,6 +62,9 @@ format_states_for_hm <- function(
   states_mat <- base::as.matrix(dplyr::select(states_w, -.data$cell_id))
   rownames(states_mat) <- states_w$cell_id
 
+  # convert NaNs to NA
+  states_mat[is.nan(states_mat)] <- NA
+
   # sort columns by chromosome and bin start_end
   states_mat <- states_mat[, gtools::mixedsort(base::colnames(states_mat))]
   if (!(state_col == "BAF" || continuous)) {

--- a/man/format_states_for_hm.Rd
+++ b/man/format_states_for_hm.Rd
@@ -4,12 +4,7 @@
 \alias{format_states_for_hm}
 \title{format states for plotting in a heatmap}
 \usage{
-format_states_for_hm(
-  states_df,
-  state_col,
-  continuous = FALSE,
-  replace_11_with_11plus = TRUE
-)
+format_states_for_hm(states_df, state_col, continuous = FALSE)
 }
 \arguments{
 \item{states_df}{long format states information}

--- a/man/generate_state_hm.Rd
+++ b/man/generate_state_hm.Rd
@@ -8,7 +8,8 @@ generate_state_hm(
   states_mat,
   labels_fontsize = 8,
   plot_cols = STATE_COLORS,
-  left_annot = NULL
+  left_annot = NULL,
+  legend_11plus = FALSE
 )
 }
 \description{

--- a/man/plot_state_hm.Rd
+++ b/man/plot_state_hm.Rd
@@ -22,7 +22,7 @@ plot_state_hm(
   custom_continuous_colors = NULL,
   custom_continuous_range = NULL,
   hm_discrete_colors = NULL,
-  replace_11_with_11plus = TRUE,
+  legend_11plus = FALSE,
   ...
 )
 }
@@ -74,8 +74,9 @@ and high bounds for the continuous color scale, e.g., c(1, 5, 10)}
 \item{hm_discrete_colors}{specified colors for the values being plotted.
 Named vector: c(1="#3182BD", 2="#FDCC8A"). Need to specify for every value}
 
-\item{replace_11_with_11plus}{bool. Default TRUE. For HMMCopy state values,
-state 11 is really 11+, so we replace 11s with 11+ for the plot.
+\item{legend_11plus}{bool. Default FALSE. For HMMCopy state values,
+state 11 is really 11+, so we replace 11s with 11+ for the plot in the
+legend.
 being plotted}
 }
 \description{

--- a/vignettes/heatmaps.Rmd
+++ b/vignettes/heatmaps.Rmd
@@ -65,6 +65,9 @@ dlptools::plot_state_hm(
   # optional, but recommended dump direct to a file with:
   file_name = "imgs/basic_hm.png"
   # recommended for full, large, heatmaps
+  # optional for HMMcopy state data, 11 is really 11+, so we can display the
+  # legend that way with
+  # legend_11plus=TRUE
 )
 ```
 


### PR DESCRIPTION
This PR addresses https://github.com/molonc/dlptools/issues/8

* NaNs are converted to NAs, which appear as white in the plot
* the notation of 11+ for CN states is optionally added just to the legend, rather than forcing conversion of the plotted heatmap values to a character
* a stop is issued if an automatically chosen color palette can't handle the states to plot.

The last point is done that way as it is not knowable how the values should appear, so it forces the user to specify manually with the `hm_discrete_colors` option.